### PR TITLE
Add autoLoadCodeMirror config variable (defaults to true).

### DIFF
--- a/codemirror/plugin.js
+++ b/codemirror/plugin.js
@@ -50,6 +50,7 @@
             }
 
             // Load CodeMirror
+            // It is assumed that either config.autoLoadCodeMirror is true (default value) or all CodeMirror js and css files are loaded manually.
             if (config.autoLoadCodeMirror) {
                 CKEDITOR.document.appendStyleSheet(rootPath + 'css/codemirror.min.css');
                 if (config.theme.length && config.theme != 'default') {
@@ -63,8 +64,6 @@
             var sourcearea = CKEDITOR.plugins.sourcearea;
             editor.addMode('source', function(callback) {
                 if (typeof(CodeMirror) == 'undefined') {
-                    // Ignoring config.autoLoadCodeMirror here. If CodeMirror isn't loaded at this point, we need to load it.
-                    // It is assumed that either config.autoLoadCodeMirror is true or all css files are loaded manually.
                     CKEDITOR.scriptLoader.load([rootPath + 'js/codemirror.min.js'].concat(getCodeMirrorScripts()), function() {
                         loadCodeMirror(editor);
                         callback();


### PR DESCRIPTION
This allows disabling CodeMirror js/css autoloading in case if it's loaded manually.

For example, one could already have CodeMirror on his page, for syntax highlighting , non-wysiwyg editors mixed with wysiwig editors, or something like that.

Adding some kind of heuristic to detect already existing CodeMirror will do no good, because simple heuristic will fail sooner or later. The user might not understand why doesn't the plugin work out of the box if he loaded plain CodeMirror without some of the needed modes/plugins, but at the sime time why does it work when he didn't load CodeMirror at all. More complex heuristic just isn't KISS.

So, a manual «opt-out» configuration option is the best choice, in my opinion.
