### PR TITLE
Add an onLoad callback.

### DIFF
--- a/codemirror/plugin.js
+++ b/codemirror/plugin.js
@@ -182,6 +182,11 @@
                         }
                     });
                 }
+
+                // Run config.onLoad callback, if present.
+                if (typeof config.onLoad == 'function') {
+                    config.onLoad(window["codemirror_" + editor.id], editor);
+                }
             }
 
             editor.addCommand('source', sourcearea.commands.source);


### PR DESCRIPTION
This callback allows to perform actions with CodeMirror object that were not hard-coded into the plugin, but specified in the configuration.
