### PR TITLE
Use the 'mode' specified in 'editor.config' 

### DIFF
--- a/codemirror/plugin.js
+++ b/codemirror/plugin.js
@@ -14,6 +14,7 @@
             var rootPath = this.path;
             // Default Config
             var defaultConfig = {
+		mode: 'text/html',
                 theme: 'default',
                 matchBrackets: true,
                 lineNumbers: true,
@@ -129,7 +130,7 @@
                 }
 
                 window["codemirror_" + editor.id] = CodeMirror.fromTextArea(sourceAreaElement.$, {
-                    mode: 'text/html',
+                    mode: config.mode,
                     matchBrackets: config.matchBrackets,
                     workDelay: 300,
                     workTime: 35,


### PR DESCRIPTION
Use the 'mode' from the configuration instead of hard-coding it. At the same time, keep the 'text/html' as the default mode.

This is useful when you need to display the source in Markdown, Asciidoc or other document format.
