### PR TITLE
Fixed CodeMirror change event not propagating to original edit field.

### DIFF
--- a/codemirror/plugin.js
+++ b/codemirror/plugin.js
@@ -68,8 +68,6 @@
                         oldData;
 
                     function loadCodeMirrorInline(editor, textarea) {
-                        var delay;
-
                         window["codemirror_" + editor.id] = CodeMirror.fromTextArea(textarea, {
                             mode: config.mode,
                             matchBrackets: config.matchBrackets,
@@ -144,15 +142,8 @@
                         }
 
                         window["codemirror_" + editor.id].on("change", function () {
-                            clearTimeout(delay);
-                            delay = setTimeout(function () {
-                                var cm = window["codemirror_" + editor.id];
-
-                                if (cm) {
-                                    cm.save();
-                                    editor.editable().fire('input');
-                                }
-                            }, 300);
+                            window["codemirror_" + editor.id].save();
+                            editor.fire('change', this);
                         });
 
                         window["codemirror_" + editor.id].setSize(holderWidth, holderHeight);
@@ -643,7 +634,7 @@
                 window["editable_" + editor.id].setData(editor.getData(1));
                 window["editable_" + editor.id].editorID = editor.id;
                 editor.fire('ariaWidget', this);
-                var delay;
+
                 var sourceAreaElement = window["editable_" + editor.id],
                     holderElement = sourceAreaElement.getParent();
 
@@ -771,14 +762,8 @@
                 }
 
                 window["codemirror_" + editor.id].on("change", function () {
-                    clearTimeout(delay);
-                    delay = setTimeout(function () {
-                        var cm = window["codemirror_" + editor.id];
-                    
-                        if (cm) {
-                            cm.save();
-                        }
-                    }, 300);
+                    window["codemirror_" + editor.id].save();
+                    editor.fire('change', this);
                 });
 
                 window["codemirror_" + editor.id].setSize(null, holderHeight);


### PR DESCRIPTION
I've come across this bug myself while using CKEditor with this plugin in an angularjs environment where I update the model on change events. I found issue #66, but the fix does not seem to work at all. The non-inline change event was missed in the fix. And when inline, it gave me a js error, because editor.editable() is undefined. I've had some reliable results with doing `editor.fire('change', this)` like it was also done with the blur event. I've also removed the unnecessary delay that will lead to more potential bugs in code relying on this event (like mine).
