### PR TITLE
Enable search button on toolbar again

### DIFF
--- a/codemirror/plugin.js
+++ b/codemirror/plugin.js
@@ -812,13 +812,13 @@
                     if (config.showFormatButton || config.showCommentButton || config.showUncommentButton || config.showSearchButton) {
                         editor.ui.add('-', CKEDITOR.UI_SEPARATOR, { toolbar: 'mode,30' });
                     }
-                    /*if (config.showSearchButton && config.enableSearchTools) {
+                    if (config.showSearchButton && config.enableSearchTools) {
                         editor.ui.addButton('searchCode', {
                             label: lang.searchCode,
                             command: 'searchCode',
                             toolbar: 'mode,40'
                         });
-                    }*/
+                    }
                     if (config.showFormatButton) {
                         editor.ui.addButton('autoFormat', {
                             label: lang.autoFormat,


### PR DESCRIPTION
Commit 7420142fabfbe5e6bde31ea2b2d7e5c3f873e832 seems to have disabled this button accidentally

Note that the button can be easily hidden by setting `config.showSearchButton = false`