### PR TITLE
Update plugin.js

### DIFF
--- a/codemirror/plugin.js
+++ b/codemirror/plugin.js
@@ -265,8 +265,11 @@
 
                                 // Avoid unnecessary setData. Also preserve selection
                                 // when user changed his mind and goes back to wysiwyg editing.
-                                if (newData === oldData)
+                                if (newData === oldData) {
+                                    editor.fire('blur', this);
+                                    editor.fire('focus', this);
                                     return true;
+                                }
 
                                 // Set data asynchronously to avoid errors in IE.
                                 CKEDITOR.env.ie ? CKEDITOR.tools.setTimeout(setData, 0, this, newData) : setData.call(this, newData);


### PR DESCRIPTION
#82
if a user with inline editor opens the codemirror modal, clicks inside the code, does not change anything and clicks on OK the CKEditor toolbar vanishes. Fixed.