### PR TITLE
Add task 'requirejs' to the default tasks in Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -276,6 +276,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-requirejs');
  
   grunt.registerTask('watch', [
+    'requirejs',
     'min',
     'cssmin',
     'imagemin',
@@ -283,6 +284,7 @@ module.exports = function(grunt) {
     ]);
 
   grunt.registerTask('default', [
+    'requirejs',
     'min',
     'cssmin',
     'imagemin'


### PR DESCRIPTION
forgot to add the requirejs task here, so that when one runs `grunt`, it actually runs the task.
