### PR TITLE
Fill "version" into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "CKEditor-CodeMirror-Plugin",
+  "version": "0.0.0",
   "author": "w8tcha",
   "description": "Syntax Highlighting for the CKEditor (Source View and Source Dialog) with the CodeMirror Plugin.",
   "repository": {


### PR DESCRIPTION
When "version" is present, this package can be npm-installed, like so:

`npm install --save w8tcha/CKEditor-CodeMirror-Plugin#v1.17`