### PR TITLE
[BUGFIX] Better checking for require.js presence

### DIFF
--- a/codemirror/plugin.js
+++ b/codemirror/plugin.js
@@ -58,7 +58,7 @@
             if (editor.plugins.bbcode && config.mode.indexOf("bbcode") <= 0) {
                 config.mode = "bbcode";
             }
-            var requirePresent = "function" === typeof require;
+            var requirePresent = "function" === typeof require && "function" === typeof require.config;
 
             if (requirePresent){
                 var location = CKEDITOR.getUrl('plugins/codemirror/js');


### PR DESCRIPTION
I have declared `require` function in my JS code and this line of code thinks that it is an instance of require.js. So it results with

> Uncaught TypeError: require.config is not a function

I don't know if there is a better way to check this, but this fixes my issue.

Linked/inspired with
https://github.com/w8tcha/CKEditor-CodeMirror-Plugin/issues/77
https://github.com/w8tcha/CKEditor-CodeMirror-Plugin/issues/134
