### PR TITLE
[BUGFIX] Checking existence of the autoCompleteToggle command

### DIFF
--- a/codemirror/plugin.js
+++ b/codemirror/plugin.js
@@ -1059,7 +1059,9 @@
                 editor.getCommand("source").setState(editor.mode === "source" ? CKEDITOR.TRISTATE_ON : CKEDITOR.TRISTATE_OFF);
 
                 if (editor.mode === "source") {
-                    editor.getCommand("autoCompleteToggle").setState(window["codemirror_" + editor.id].config.autoCloseTags ? CKEDITOR.TRISTATE_ON : CKEDITOR.TRISTATE_OFF);
+                    if ("autoCompleteToggle" in editor.commands) {
+                        editor.getCommand("autoCompleteToggle").setState(window["codemirror_" + editor.id].config.autoCloseTags ? CKEDITOR.TRISTATE_ON : CKEDITOR.TRISTATE_OFF);
+                    }
 
                     if (editor.plugins.textselection && textRange && !editor.config.fullPage) {
 


### PR DESCRIPTION
When `showAutoCompleteButton = false`, error message is output to console when mode is switched to source
```
ckeditor.js:1379 Uncaught TypeError: Cannot read property 'setState' of undefined
```
Fix to check if `autoCompleteToggle` command exists.


