### PR TITLE
Handle case when getUrl adds ?t= argument

### DIFF
--- a/codemirror/plugin.js
+++ b/codemirror/plugin.js
@@ -72,7 +72,8 @@
             var pluginRequire;
             if (requirePresent){
                 var requireContext = config.requireContext || "_";
-                var location = CKEDITOR.getUrl("plugins/codemirror/js");
+                var location = CKEDITOR.getUrl("plugins/codemirror/js/");
+                location = location.substring(0, location.length - 1);
                 pluginRequire = require.config({
                     context: requireContext,
                     packages: [{


### PR DESCRIPTION
CKEDITOR.getUrl("plugins/codemirror/js") can generate URL with the ?t=<timestamp> added at the end that is passed to require.config (which then results in wrong URLs being used).
If we add the trailing slash, the resulting url does not contain the ?t argument and can be safely used.