### PR TITLE
Fix context menu (again)

### DIFF
--- a/codemirror/plugin.js
+++ b/codemirror/plugin.js
@@ -175,7 +175,8 @@
                             gutters: ["CodeMirror-linenumbbers", "CodeMirror-foldgutter"]
                         });
        
-
+                        window["codemirror_" + editor.id].display.wrapper.classList.add('cke_enable_context_menu');
+                        
                         var holderHeight = height + "px";
                         var holderWidth = width + "px";
 
@@ -905,6 +906,8 @@
                     foldGutter: true,
                     gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
                 });
+                
+                window["codemirror_" + editor.id].display.wrapper.classList.add('cke_enable_context_menu');
 
                 var holderHeight = holderElement.$.clientHeight == 0 ? editor.ui.space("contents").getStyle("height") : holderElement.$.clientHeight + "px";
                 var holderWidth = holderElement.$.clientWidth + "px";
@@ -1101,9 +1104,6 @@
             });
 
             editor.on("instanceReady", function (evt) {
-
-                //editor.container.getPrivate().events.contextmenu.listeners.splice(0, 1);
-
                 var selectAllCommand = editor.commands.selectAll;
 
                 // Replace Complete SelectAll command from the plugin, otherwise it will not work in IE10


### PR DESCRIPTION
It was partially fixed in #9, but reverted in #90 and #91.

This fix just adds `.cke_enable_context_menu` to the codemirror container element and it seems everything is working great. 

Tested on CKEditor 4.14.

Tmp workaround:
```js
// config.js
config.codemirror = {
  onLoad(codeMirror, editor) {
    codeMirror.display.wrapper.classList.add('cke_enable_context_menu');
  }
};
```

<hr>

UPD: 
I also noticed that sometimes the context menu may not open the first time if the option `config.codemirror.matchTags` is set to true (by default). When the caret changes its position to a tag to highlight, this tag is replaced by a new one (by the codemirror addon), but CKEditor tries to find `.cke_enable_context_menu` from the old one that no longer exists in the document. That's why `event.preventDefault` is called in this case: there is no `.cke_enable_context_menu` parent element. Workaround is 
```js
config.codemirror = {
  matchTags: false
}
```
I don't see how this can be fixed easily.