### PR TITLE
Fixed missing closing bracket

### DIFF
--- a/codemirror/css/codemirror.ckeditor.css
+++ b/codemirror/css/codemirror.ckeditor.css
@@ -199,3 +199,4 @@
 .CodeMirror-merge-editor {
 	position: absolute;
 	left: 0;
+}


### PR DESCRIPTION
I encountered an issue with Webpack Css Minimizer plugin because the closing bracket is missing:

>  ERROR  Failed to compile with 1 errors                 
error  in ckeditor/plugins/codemirror/css/codemirror.ckeditor.css from Css Minimizer plugin
Unclosed block [ckeditor/plugins/codemirror/css/codemirror.ckeditor.css:199,1]